### PR TITLE
feat: add DeepInfra and Edgee to developer infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,8 @@ GPU clouds, hosted inference, and fine-tuning platforms for deploying models at 
 
 - [Adaptive ML](https://www.adaptive-ml.com) - Reinforcement-learning platform for post-training, evaluating, and serving enterprise-specialized open models.
 - [CoreWeave](https://www.coreweave.com) - GPU cloud purpose-built for AI, offering large-scale NVIDIA clusters for training and inference.
+- [DeepInfra](https://deepinfra.com) - Serverless inference cloud for open-weight models across text, embeddings, speech, image, and video, billed per token with no minimums and no idle GPU charges.
+- [Edgee](https://edgee.ai) - Agent gateway that sits between coding agents and LLM providers, applying budget-driven routing, gateway-side token compression, and per-developer cost attribution across Claude Code, Codex, Cursor, and Copilot.
 - [Fireworks AI](https://fireworks.ai) - Inference and fine-tuning platform for open-weight models with low-latency routing.
 - [FlexAI](https://flex.ai) - Universal AI compute platform that abstracts heterogeneous hardware so developers can train, fine-tune, and serve models without managing infrastructure.
 - [Hugging Face](https://huggingface.co) - The hub for open models, datasets, and Spaces, plus the Transformers library and hosted inference that anchor the open-source AI ecosystem.


### PR DESCRIPTION
Adds two entries to `### Developer infrastructure`, inserted in the existing alphabetical order between CoreWeave and Fireworks AI.

- **[DeepInfra](https://deepinfra.com)** — serverless, per-token inference for open-weight models across text, embeddings, speech, image, and video.
- **[Edgee](https://edgee.ai)** — agent gateway between coding agents and LLM providers, doing budget-driven routing, token compression, and per-developer cost attribution.

### Why these clear the bar

Both are AI-native in the CONTRIBUTING sense: remove the model layer and neither product has a reason to exist. Edgee also fills a slot the list did not represent — a gateway specifically for coding-agent traffic, rather than a general model marketplace.

Descriptions state what each product does, with no vendor performance or cost-savings claims.

### Notes

- `awesome-lint`: 0 errors. The 2 remaining warnings (`Llama`, `Dao`) are pre-existing and untouched by this PR.
- No duplicate URLs introduced.
- README-only; the site is generated from it at build time and needs no change.