### PR TITLE
chore(readme): silence awesome-spell-check false positives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,10 +27,12 @@ Key formatting rules enforced by awesome-lint:
 - All headings must appear in the `## Contents` ToC
 - Table pipes must be aligned
 
+The `awesome-spell-check` rule flags proper nouns it mistakes for technology terms (`Llama` the Meta model, `Dao` the researcher). Silence a genuine false positive with `<!--lint ignore awesome-spell-check-->` on the line directly above the entry — never reword a correct name to satisfy the linter.
+
 ## Site (site/)
 
 The site is a minimal Astro static site. It reads `../README.md` at build time via `site/src/lib/readme.ts`, which:
-- Strips `<!--lint disable/enable-->` pragma comments
+- Strips `<!--lint disable/enable/ignore-->` pragma comments
 - Parses Markdown with `marked` (GFM tables + raw HTML)
 - Wraps `<table>` in `<div class="table-wrapper">` for responsive scroll
 - Rewrites relative `.md` links to GitHub URLs

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ LLM families released with downloadable weights you can run, fine-tune, and self
 - [GLM](https://z.ai) - Open-weight General Language Model family from Z.ai, formerly Zhipu AI, targeting long-horizon agentic and coding tasks.
 - [gpt-oss](https://github.com/openai/gpt-oss) - OpenAI's open-weight reasoning models released under Apache 2.0 and designed to run on single-GPU or consumer hardware.
 - [Kimi](https://huggingface.co/moonshotai) - Moonshot AI's Kimi family of large mixture-of-experts open-weight models, strong on agentic and coding tasks.
+<!--lint ignore awesome-spell-check-->
 - [Llama](https://www.llama.com) - Meta's widely deployed open model family, with natively multimodal mixture-of-experts architectures.
 - [MiniMax](https://www.minimax.io) - Lab releasing frontier-class open-weight reasoning and coding models under MIT-style licenses.
 - [Mistral](https://mistral.ai) - Lab releasing open-weight dense and mixture-of-experts models under Apache 2.0.
@@ -521,6 +522,7 @@ The research papers that define modern LLMs: architecture, scaling, reasoning, a
 - [Attention Is All You Need](https://arxiv.org/abs/1706.03762) - Vaswani et al., 2017. The transformer: self-attention, multi-head attention, and positional encoding, the architecture everything else builds on.
 - [Chain-of-Thought Prompting](https://arxiv.org/abs/2201.11903) - Wei et al., 2022. Showed reasoning can be elicited by prompting alone; the conceptual seed for later reasoning work.
 - [DeepSeek-R1](https://arxiv.org/abs/2501.12948) - Guo et al., 2025. Reasoning behavior emerging from reinforcement learning (GRPO) rather than prompting or SFT; the current post-training frontier.
+<!--lint ignore awesome-spell-check-->
 - [FlashAttention](https://arxiv.org/abs/2205.14135) - Dao et al., 2022. IO-aware exact attention that treats the GPU memory hierarchy as the real bottleneck, which is why long context and cheap inference are practical.
 - [Kimi k1.5: Scaling RL with LLMs](https://arxiv.org/abs/2501.12599) - Moonshot AI, 2025. The other major RL-reasoning report alongside DeepSeek-R1, with more long-context and infrastructure detail; together they define the reasoning-model recipe.
 - [RULER](https://arxiv.org/abs/2404.06654) - Hsieh et al., 2024. Benchmark measuring the real usable context length of long-context models beyond simple retrieval.

--- a/site/src/lib/readme.ts
+++ b/site/src/lib/readme.ts
@@ -17,7 +17,7 @@ function githubSlug(text: string): string {
 
 function preprocessMarkdown(md: string): string {
   // Strip awesome-lint pragma comments
-  md = md.replace(/<!--lint\s+(disable|enable)[^>]*-->\n?/g, '');
+  md = md.replace(/<!--lint\s+(disable|enable|ignore)[^>]*-->\n?/g, '');
 
   // Strip <div align="center"> wrappers — marked does not parse markdown inside HTML blocks,
   // so the H1 heading and badges would render as raw text. Removing the wrapper lets marked


### PR DESCRIPTION
`awesome-lint` reported two `awesome-spell-check` warnings. Both are false positives, so they are suppressed rather than "fixed" — rewording either name would introduce a real error.

| Line | Warning | Why it is wrong |
| --- | --- | --- |
| `README.md:291` | `Llama` → `LLaMA` | Meta dropped the `LLaMA` styling after v1; [llama.com](https://www.llama.com) brands the family `Llama`. |
| `README.md:521` | `Dao` → `DAO` | That is Tri Dao, the FlashAttention author, not a decentralized autonomous organization. |

Each entry gets a scoped `<!--lint ignore awesome-spell-check-->` on the line above.

Two supporting changes:
- `site/src/lib/readme.ts` — the pragma stripper handled `disable`/`enable` only, so `ignore` comments would have leaked into the rendered HTML. Extended to cover it.
- `CLAUDE.md` — documents the rule and the convention for future entries.

Verified: `awesome-lint` now reports 0 errors and 0 warnings; `npm run build` succeeds; the rendered HTML contains no leftover pragmas and both entries stay contiguous `<li>` siblings (the comments do not split the lists).

Independent of #12 — branched from `main`, no overlapping lines.