### PR TITLE
Add XiuRouter to gateways and routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ Proxies sitting in front of model providers to route, meter, and govern traffic.
 
 - [Edgee](https://edgee.ai) - Agent gateway that sits between coding agents and LLM providers, applying budget-driven routing, gateway-side token compression, and per-developer cost attribution across Claude Code, Codex, Cursor, and Copilot.
 - [OpenRouter](https://openrouter.ai) - Unified API and marketplace routing requests across hundreds of models and providers.
+- [XiuRouter](https://router.xiu.ai) - Hosted model API gateway with client-specific setup paths for coding agents and applications, including Codex, Claude Code, Cursor, OpenCode, and Cline.
 
 ### Sandboxes
 


### PR DESCRIPTION
Adds XiuRouter to the existing Gateways and routing section.

XiuRouter is a shipped hosted model API gateway with public client-specific setup paths for coding agents and applications, including Codex, Claude Code, Cursor, OpenCode, and Cline. The entry follows the repository format and alphabetical order, uses the canonical homepage, and has no duplicate entry in the README or existing issues/PRs.