### PR TITLE
Add Agent QA under Testing and QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ See also:
   - [Coding agents](#coding-agents)
   - [Code understanding and docs](#code-understanding-and-docs)
   - [App builders](#app-builders)
+  - [Testing and QA](#testing-and-qa)
 - [Knowledge work](#knowledge-work)
   - [Search and research](#search-and-research)
   - [Knowledge management](#knowledge-management)
@@ -151,6 +152,12 @@ Pure vibe-coding platforms that turn a plain-language description into a working
 - [Lovable](https://lovable.dev) - Prompt-to-app builder that ships full-stack web apps from a chat window.
 - [Replit Agent](https://replit.com/agent) - Browser-based agent that builds, runs, and deploys full-stack applications from natural-language prompts.
 - [v0](https://v0.app) - Vercel's generative UI tool that produces production-ready React and Tailwind components.
+
+### Testing and QA
+
+Tools that use language models to author and execute application tests.
+
+- [Agent QA](https://github.com/vostride/agent-qa) - Uses LLMs to run natural-language web, Android, and iOS tests with execution memory and UI recovery; source-available under FSL-1.1-ALv2.
 
 ## Knowledge work
 


### PR DESCRIPTION
## Description

Adds **Testing and QA** under **Vibe-coding and vibe-engineering**, with a matching Contents link and one Agent QA entry. Application regression testing is a distinct workflow alongside coding and app building; the existing evaluation section concerns models and agents. Agent QA uses LLMs to interpret natural-language test intent, operate application UIs, and evaluate assertions, so the model is central to its testing workflow.

## Checklist

- [x] Entry follows the required name/link/single-sentence format.
- [x] The new subsection is alphabetical and appears in Contents.
- [x] The HTTPS link points to the official project.
- [x] The LLM is central to the product workflow.
- [x] The description explains what the tool does.
- [x] The project is shipping, maintained, and publicly available.
- [x] No duplicate entry.

## New product submission

| Field | Value |
| --- | --- |
| Product name | Agent QA |
| URL | https://github.com/vostride/agent-qa |
| Target section | Vibe-coding and vibe-engineering → Testing and QA |
| Why it belongs here | LLM-driven natural-language application testing, with execution memory and UI recovery. |

## Validation

- Checked the current README and all-state PRs/issues for `agent-qa`, `Agent QA`, and `vostride`; no duplicate was found.
- Verified the canonical repository, official documentation/quickstart, and license URLs.
- `git diff --check` passes.
- `awesome-lint README.md` passes with zero errors.
- `awesome_bot --allow-redirect` passes with the repository’s unchanged whitelist and a bounded per-link timeout.
- Locked `npm ci --ignore-scripts` and `npm run build` pass (10 pages).
- The local production preview returns HTTP 200 for the homepage and vibe-coding category; both contain one canonical Agent QA link and the FSL disclosure, and the homepage Contents link reaches the new heading.
- Changes are in the canonical README; existing site tooling generates the pages. These are served-HTML checks, not an interactive browser test.

## Product facts and disclosure

Agent QA is source-available under FSL-1.1-ALv2, with each release converting to Apache-2.0 after two years. There is no software fee for permitted use; configured model, browser, and device-provider costs are separate.

Sources: [repository](https://github.com/vostride/agent-qa), [official overview](https://vostride.com/docs/agent-qa), and [quickstart](https://vostride.com/docs/agent-qa/quickstart).

Disclosure: this is an affiliated Agent QA contribution, prepared with AI assistance and checked against the current source and documentation.
